### PR TITLE
NXBT-3879: Set status to upstream repository if GitHub status parameters are given

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
 
   environment {
     NUXEO_DOCKER_REPOSITORY = "${isTriggered() ? DOCKER_REGISTRY : PRIVATE_DOCKER_REGISTRY}/nuxeo/nuxeo"
-    NUXEO_VERSION = "${hasNuxeoVersionParameter() ? params.NUXEO_VERSION : '2021.x'}"
+    NUXEO_VERSION = "${hasNuxeoVersionParameter() ? params.NUXEO_VERSION : '2023.x'}"
     NUXEO_LTS_JOB = 'nuxeo/lts/nuxeo'
     NAMESPACE = "nuxeo-rest-api-tests-$BRANCH_NAME-$BUILD_NUMBER".toLowerCase()
   }


### PR DESCRIPTION
Some information about causes/upstream:
| | Causes | Upstream |
|--------|--------|--------|
| Triggered by Build button | `[[_class:hudson.model.Cause$UserIdCause, shortDescription:Started by user Kevin Leturc, userId:kevinleturc, userName:Kevin Leturc]]` |`[]` |
| Triggered by nuxeo-lts PR | `[[_class:org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause, shortDescription:Started by upstream project "nuxeo/lts/nuxeo/PR-3450" build number 1, upstreamBuild:1, upstreamProject:nuxeo/lts/nuxeo/PR-3450, upstreamUrl:job/nuxeo/job/lts/job/nuxeo/job/PR-3450/]]` | `[org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper@2c0b805e]` |
| Triggered by a rebuild of previous job triggered by nuxeo-lts PR | `[[_class:org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause, shortDescription:Started by upstream project "nuxeo/lts/nuxeo/PR-3450" build number 1, upstreamBuild:1, upstreamProject:nuxeo/lts/nuxeo/PR-3450, upstreamUrl:job/nuxeo/job/lts/job/nuxeo/job/PR-3450/], [_class:hudson.model.Cause$UserIdCause, shortDescription:Started by user Kevin Leturc, userId:kevinleturc, userName:Kevin Leturc], [_class:com.sonyericsson.rebuild.RebuildCause, shortDescription:Rebuilds build #3, upstreamBuild:3, upstreamProject:nuxeo/rest-api-compatibility-tests/PR-45, upstreamUrl:job/nuxeo/job/rest-api-compatibility-tests/view/change-requests/job/PR-45/]]` | `[org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper@23969965, org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper@7e879fc0, org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper@2c6966c5]` |
| Triggered by a replay of rebuilt previous job triggered by nuxeo-lts PR | `[[_class:hudson.model.Cause$UserIdCause, shortDescription:Started by user Kevin Leturc, userId:kevinleturc, userName:Kevin Leturc], [_class:org.jenkinsci.plugins.workflow.cps.replay.ReplayCause, shortDescription:Replayed #4]]` | `[]` |
